### PR TITLE
iTunes リンクのフォーマットを調整

### DIFF
--- a/SlackMood/Services/SlackPostingService.swift
+++ b/SlackMood/Services/SlackPostingService.swift
@@ -58,8 +58,11 @@ class SlackPostingService: NSObject {
         let name = item.name ?? unknown
         let artist = item.artist ?? unknown
         let album = item.album ?? unknown
-        let url = item.url ?? unknown
-
-        return "Now Playing: *\(name)* by *\(artist)* from *\(album)* (\(url))"
+        if let url = item.url {
+            return "Now Playing: *\(name)* by *\(artist)* from :cd: <\(url)|\(album)>"
+        }
+        else {
+            return "Now Playing: *\(name)* by *\(artist)* from :cd: *\(album)*"
+        }
     }
 }


### PR DESCRIPTION
## 概要

`<url|text>` なフォーマットでポストすると `<a href="url">text</a>` という表記にできるので、この方式でアルバムタイトルがリンクになるようにしました。
## 検討事項
- アルバムタイトルじゃなくて、曲名をリンクにした方が良いですかね？
- アルバムタイトルはあったりなかったりするので、ない場合はそもそも非表示でも良いかも。
- 実は `<` `>` `&` はクライアントがエスケープしないといけないので、曲名とかアーティスト名とかの素のテキストは要対応。
