### PR TITLE
設定ファイルの置き場を絶対パスに修正

### DIFF
--- a/SlackMood/Services/SlackApiConfigService.swift
+++ b/SlackMood/Services/SlackApiConfigService.swift
@@ -60,7 +60,7 @@ class SlackApiConfigService: NSObject {
 
         let root = paths[0] as? String
         return root.map {
-            $0.stringByAppendingPathComponent("SlackMood")
+            $0.stringByAppendingPathComponent("SlackMood").stringByExpandingTildeInPath
         }
     }
 


### PR DESCRIPTION
## 概要

`~/Library/Application Support/SlackMood` だったのを絶対パスに直しました。

既存の定義ファイルを回収するには、

``` bash
$ mkdir ~/Library/Application\ Support/SlackMood
$ cp ~/Library/Developer/Xcode/DerivedData/SlackMood-*/Build/Products/Debug/\~/Library/Application\ Support/SlackMood/slack-api.plist ~/Library/Application\ Support/SlackMood/
```

あたりで行けるかと。
