### PR TITLE
API token を keychain に保存するようにした

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,3 +3,4 @@ platform :osx, "10.9"
 use_frameworks!
 
 pod 'Alamofire'
+pod 'KeychainAccess'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,13 @@
 PODS:
   - Alamofire (1.3.1)
+  - KeychainAccess (1.2.1)
 
 DEPENDENCIES:
   - Alamofire
+  - KeychainAccess
 
 SPEC CHECKSUMS:
   Alamofire: e4ab637e3195b645c814b87a652373439e59f2a4
+  KeychainAccess: 3d7922baf90762a976adb7f6030d74c1a4110a1d
 
 COCOAPODS: 0.38.2

--- a/SlackMood/Services/SlackApiConfigService.swift
+++ b/SlackMood/Services/SlackApiConfigService.swift
@@ -13,6 +13,7 @@ class SlackApiConfigService: NSObject {
     func save(config: SlackApiConfig) {
         FileStore().save(config)
         KeychainStore().saveApiToken(config.token)
+        notifyUpdate(config)
     }
 
     func load() -> SlackApiConfig? {
@@ -39,6 +40,15 @@ class SlackApiConfigService: NSObject {
                 SlackApiConfig(channel: channel, token: token)
             }
         }
+    }
+
+    private func notifyUpdate(config: SlackApiConfig) {
+        let notification = NSNotification(name: "slackmood.apiConfig.updated", object: config)
+        notificationCenter().postNotification(notification)
+    }
+
+    private func notificationCenter() -> NSNotificationCenter {
+        return NSNotificationCenter.defaultCenter()
     }
 
     class FileStore: NSObject {

--- a/SlackMood/Services/SlackApiConfigService.swift
+++ b/SlackMood/Services/SlackApiConfigService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KeychainAccess
 
 class SlackApiConfigService: NSObject {
     static let instance = SlackApiConfigService()
@@ -10,27 +11,26 @@ class SlackApiConfigService: NSObject {
     }
 
     func save(config: SlackApiConfig) {
-        if let directory = documentDirectory() {
-            ensureDirectory(directory)
-
-            let data: NSDictionary = [
-                "channel": config.channel,
-                "token": config.token
-            ]
-            let path = dataFilePath(directory)
-            data.writeToFile(path, atomically: true)
-        }
+        FileStore().save(config)
+        KeychainStore().saveApiToken(config.token)
     }
 
     func load() -> SlackApiConfig? {
-        if let directory = documentDirectory() {
-            let path = dataFilePath(directory)
-            if let data = NSDictionary(contentsOfFile: path) {
+        if let data = FileStore().load() {
+            if let token = loadToken() {
+                let dic = NSMutableDictionary(dictionary: data)
+                dic.setValue(token, forKey: "token")
+                return createConfig(dic)
+            }
+            else {
                 return createConfig(data)
             }
-
         }
         return nil
+    }
+
+    func loadToken() -> String? {
+        return KeychainStore().loadApiToken()
     }
 
     private func createConfig(data: NSDictionary) -> SlackApiConfig? {
@@ -41,37 +41,76 @@ class SlackApiConfigService: NSObject {
         }
     }
 
-    private func ensureDirectory(path: String) {
-        var error: NSError?
+    class FileStore: NSObject {
+        func save(config: SlackApiConfig) {
+            if let directory = documentDirectory() {
+                ensureDirectory(directory)
 
-        let manager = NSFileManager.defaultManager()
-        if manager.fileExistsAtPath(path) {
-            return
+                let data: NSDictionary = [
+                    "channel": config.channel,
+                ]
+                let path = dataFilePath(directory)
+                data.writeToFile(path, atomically: true)
+            }
         }
 
-        let success = manager.createDirectoryAtPath(path, withIntermediateDirectories: true, attributes: nil, error: &error)
-        if !success {
-            println("Failed to create directory \(path) : \(error)")
+        func load() -> NSDictionary? {
+            if let directory = documentDirectory() {
+                let path = dataFilePath(directory)
+                return NSDictionary(contentsOfFile: path)
+            }
+            return nil
+        }
+
+        private func ensureDirectory(path: String) {
+            var error: NSError?
+
+            let manager = NSFileManager.defaultManager()
+            if manager.fileExistsAtPath(path) {
+                return
+            }
+
+            let success = manager.createDirectoryAtPath(path, withIntermediateDirectories: true, attributes: nil, error: &error)
+            if !success {
+                println("Failed to create directory \(path) : \(error)")
+            }
+        }
+
+        private func documentDirectory() -> String? {
+            let paths = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.ApplicationSupportDirectory, NSSearchPathDomainMask.UserDomainMask, false)
+
+            let root = paths[0] as? String
+            return root.map {
+                $0.stringByAppendingPathComponent("SlackMood").stringByExpandingTildeInPath
+            }
+        }
+
+        private func dataFilePath(prefix: String) -> String {
+            return prefix.stringByAppendingPathComponent("slack-api.plist")
         }
     }
 
-    private func documentDirectory() -> String? {
-        let paths = NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory.ApplicationSupportDirectory, NSSearchPathDomainMask.UserDomainMask, false)
+    class KeychainStore: NSObject {
+        private let keychain = Keychain()
+        private let key = "slack-api-token"
 
-        let root = paths[0] as? String
-        return root.map {
-            $0.stringByAppendingPathComponent("SlackMood").stringByExpandingTildeInPath
+        func loadApiToken() -> String? {
+            let failable = keychain.getStringOrError(key)
+            switch failable {
+            case .Success:
+                return failable.value
+            case .Failure:
+                println(failable.error)
+                return nil
+            }
         }
-    }
 
-    private func dataFilePath(prefix: String) -> String {
-        return prefix.stringByAppendingPathComponent("slack-api.plist")
-    }
+        func saveApiToken(token: String) {
+            keychain.set(token, key: key)
+        }
 
-    private func createPropertyList(config: SlackApiConfig) -> NSDictionary {
-        return [
-            "channel": config.channel,
-            "token": config.token
-        ]
+        func destroyApiToken() {
+            keychain.remove(key)
+        }
     }
 }

--- a/SlackMood/Services/SlackPostingService.swift
+++ b/SlackMood/Services/SlackPostingService.swift
@@ -11,6 +11,13 @@ class SlackPostingService: NSObject {
     }
 
     private override init() {
+        super.init()
+        observeApiConfig()
+    }
+
+    deinit {
+        stop()
+        unobserveApiConfig()
     }
 
     func start() {
@@ -74,5 +81,21 @@ class SlackPostingService: NSObject {
                 .stringByReplacingOccurrencesOfString(">", withString: "&gt;")
         }
         return str
+    }
+
+    let apiConfigNotificationName = "slackmood.apiConfig.updated"
+
+    private func observeApiConfig() {
+        notificationCenter().addObserver(self, selector: "didApiConfigUpdated:", name: apiConfigNotificationName, object: nil)
+    }
+
+    private func unobserveApiConfig() {
+        notificationCenter().removeObserver(self, name: apiConfigNotificationName, object: nil)
+    }
+
+    func didApiConfigUpdated(notification: NSNotification) {
+        if let config = notification.object as? SlackApiConfig {
+            slackApiConfig = config
+        }
     }
 }

--- a/SlackMood/Services/SlackPostingService.swift
+++ b/SlackMood/Services/SlackPostingService.swift
@@ -3,6 +3,7 @@ import Alamofire
 
 class SlackPostingService: NSObject {
     let postingUri = "https://slack.com/api/chat.postMessage"
+    var slackApiConfig: SlackApiConfig? = SlackApiConfigService.sharedService().load()
 
     static let instance = SlackPostingService()
     class func sharedService() -> SlackPostingService {
@@ -31,7 +32,7 @@ class SlackPostingService: NSObject {
     }
 
     private func post(item: PlayingItem) {
-        if let config = SlackApiConfigService.sharedService().load() {
+        if let config = slackApiConfig {
             let message = createMessage(item)
             println(message)
 


### PR DESCRIPTION
## 概要

token を Keychain に入れておくように調整しました。
今のところ、
- 既存の設定ファイル上にまだ token が入っていれば、その値を使う
- Keychain に token があれば、そちらを優先的に使う
- 設定を保存する場合は、
  - ファイルには書かない
  - Keychain に保存する

という動作にしてあります。
## 制限事項

Keychain を正しく使うには developer ID が必要らしいので、現状だと不完全です。
(エラーを返しつつも、いちおう保存されるようですが)
