### PR TITLE
Keychain 関連を修正

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,4 +3,4 @@ platform :osx, "10.9"
 use_frameworks!
 
 pod 'Alamofire'
-pod 'KeychainAccess', git: 'https://github.com/kishikawakatsumi/KeychainAccess.git', branch: 'swift-2.0'
+pod 'KeychainAccess', '~> 2.0.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,24 +1,13 @@
 PODS:
   - Alamofire (2.0.1)
-  - KeychainAccess (1.2.1)
+  - KeychainAccess (2.0.0)
 
 DEPENDENCIES:
   - Alamofire
-  - KeychainAccess (from `https://github.com/kishikawakatsumi/KeychainAccess.git`,
-    branch `swift-2.0`)
-
-EXTERNAL SOURCES:
-  KeychainAccess:
-    :branch: swift-2.0
-    :git: https://github.com/kishikawakatsumi/KeychainAccess.git
-
-CHECKOUT OPTIONS:
-  KeychainAccess:
-    :commit: 38ea7f3e8f40d878bc040e2dc9109ea29326b1d5
-    :git: https://github.com/kishikawakatsumi/KeychainAccess.git
+  - KeychainAccess (~> 2.0.0)
 
 SPEC CHECKSUMS:
   Alamofire: 1d8e208d616fbbfd2391b15eae766d07c96cdc49
-  KeychainAccess: 2ffa8b1b7130263bb7fe90b359d778696fc2d8ce
+  KeychainAccess: 1e705665a234b3af69d653aaa3c8f696e4a992f1
 
-COCOAPODS: 0.38.2
+COCOAPODS: 0.39.0.beta.4

--- a/SlackMood/Info.plist
+++ b/SlackMood/Info.plist
@@ -32,5 +32,7 @@
 	<string>Menu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>AppIdentifierPrefix</key>
+	<string>$(AppIdentifierPrefix)</string>
 </dict>
 </plist>

--- a/SlackMood/Services/SlackApiConfigService.swift
+++ b/SlackMood/Services/SlackApiConfigService.swift
@@ -97,8 +97,21 @@ class SlackApiConfigService: NSObject {
     }
 
     class KeychainStore: NSObject {
-        private let keychain = Keychain()
+        private let keychain: Keychain
         private let key = "slack-api-token"
+
+        override init() {
+            let bundle = NSBundle.mainBundle()
+            let appPrefix = bundle.objectForInfoDictionaryKey("AppIdentifierPrefix")
+            let bundleIdentifier = bundle.bundleIdentifier
+
+            if let prefix = appPrefix, id = bundleIdentifier {
+                keychain = Keychain(accessGroup: "\(prefix)\(id)")
+            }
+            else {
+                keychain = Keychain()
+            }
+        }
 
         func loadApiToken() -> String? {
             if let value = try? keychain.getString(key) {

--- a/SlackMood/Services/SlackApiConfigService.swift
+++ b/SlackMood/Services/SlackApiConfigService.swift
@@ -1,13 +1,13 @@
 import Foundation
 import KeychainAccess
 
-class SlackApiConfigService: NSObject {
+class SlackApiConfigService {
     static let instance = SlackApiConfigService()
     class func sharedService() -> SlackApiConfigService {
         return instance
     }
 
-    private override init() {
+    private init() {
     }
 
     func save(config: SlackApiConfig) {
@@ -51,7 +51,7 @@ class SlackApiConfigService: NSObject {
         return NSNotificationCenter.defaultCenter()
     }
 
-    class FileStore: NSObject {
+    class FileStore {
         func save(config: SlackApiConfig) {
             if let rootUrl = documentRootUrl() {
                 ensureRootUrl(rootUrl)
@@ -96,11 +96,11 @@ class SlackApiConfigService: NSObject {
         }
     }
 
-    class KeychainStore: NSObject {
+    class KeychainStore {
         private let keychain: Keychain
         private let key = "slack-api-token"
 
-        override init() {
+        init() {
             let bundle = NSBundle.mainBundle()
             let appPrefix = bundle.objectForInfoDictionaryKey("AppIdentifierPrefix")
             let bundleIdentifier = bundle.bundleIdentifier


### PR DESCRIPTION
## 概要
- KeychainAccess 2.0.0 を使うように変更
- Keychain の accessGroup に application identifier を明示的に指定するように修正

keychain の使い方が微妙に間違っていたっぽいので修正しました。
## 備考

ビルドするには cocoapods を 0.39.0.beta.4 に上げて `pod install` しないといけないかもです。
